### PR TITLE
fix: Migrate all nctu related link to nycu

### DIFF
--- a/frontend/src/Components/navbar.js
+++ b/frontend/src/Components/navbar.js
@@ -263,8 +263,8 @@ const Navbar = (props) => {
                         <Divider />
                         <List>
                             <ListItem disabled >外部連結</ListItem>
-                            <ListItem button onClick={() => window.location.href = "https://timetable.nctu.edu.tw/"}>交大課程時間表</ListItem>
-                            <ListItem button onClick={() => window.location.href = "https://course.nctu.edu.tw/"}>交大選課系統</ListItem>
+                            <ListItem button onClick={() => window.location.href = "https://timetable.nycu.edu.tw/"}>交大課程時間表</ListItem>
+                            <ListItem button onClick={() => window.location.href = "https://course.nycu.edu.tw/"}>交大選課系統</ListItem>
                         </List>
                         <Divider />
                         <List>

--- a/frontend/src/Pages/gpa/import/index.js
+++ b/frontend/src/Pages/gpa/import/index.js
@@ -65,7 +65,7 @@ export default (props) => {
           </Typography>
           <Typography>
             1. 登入交大註冊組{" "}
-            <Link href="https://regist.nctu.edu.tw/" target="_blank">
+            <Link href="https://regist.nycu.edu.tw/" target="_blank">
               學籍成績系統
             </Link>
             <br />

--- a/frontend/src/Util/dataUtil/course.js
+++ b/frontend/src/Util/dataUtil/course.js
@@ -112,7 +112,7 @@ export function makeInfoPageUrl(courseId) {
     let [time, no] = courseId.split('_')
     let acy = time.slice(0, time.length - 1)
     let sem = time.slice(time.length - 1)
-    return `https://timetable.nctu.edu.tw/?r=main/crsoutline&Acy=${acy}&Sem=${sem}&CrsNo=${no}&lang=zh-tw`
+    return `https://timetable.nycu.edu.tw/?r=main/crsoutline&Acy=${acy}&Sem=${sem}&CrsNo=${no}&lang=zh-tw`
 }
 
 export function filterCommonCourses(allCourses, categoryMap, category) {


### PR DESCRIPTION
Currently, all webpages relate to `.nctu.edu.tw` are deprecated. This PR aims to migrate all these links to `.nycu.edu.tw`.